### PR TITLE
Use cl-lib

### DIFF
--- a/window-number.el
+++ b/window-number.el
@@ -106,7 +106,7 @@
 
 ;;; Require
 
-(require 'cl)                           ; for set-difference and loop
+(require 'cl-lib)                           ; for set-difference and loop
 
 ;;; Code:
 
@@ -144,7 +144,7 @@
   "Returns a list of the windows, in fixed order and the
 minibuffer (even if not active) last."
   (let* ((walk-windows-start
-          (car (set-difference
+          (car (cl-set-difference
                 (window-list (selected-frame) t)
                 (window-list (selected-frame) 1))))
          (walk-windows-current walk-windows-start)
@@ -227,7 +227,7 @@ Prompt user input window number if have more windows."
 
 (defmacro window-number-define-keys (mode-map prefix)
   `(progn
-     ,@(loop for number from 1 to 10 collect
+     ,@(cl-loop for number from 1 to 10 collect
              `(define-key ,mode-map
                 (kbd ,(concat prefix (number-to-string
                                       (if (>= number 10) 0 number))))


### PR DESCRIPTION
Thank you for maintaining window-number!  I've been using window-number for many years, but the deprecation warning about cl has been bothering me since Emacs 27. 

Here's a small fix that hopefully should not break anything.